### PR TITLE
fixing deprecated warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
     line: "{{ item.line }}"
     insertafter: EOF
     state: present
-  with_items: raspberry_pi_boot_config_options
+  with_items: "{{ raspberry_pi_boot_config_options}} "
 
 - name: Configure options in /etc/rc.local.
   lineinfile:
@@ -15,4 +15,4 @@
     line: "{{ item.line }}"
     insertbefore: "^exit"
     state: present
-  with_items: raspberry_pi_rc_local_options
+  with_items: " {{ raspberry_pi_rc_local_options }} "


### PR DESCRIPTION
Fixing bare variables. Example warning:
`[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax
('{{raspberry_pi_rc_local_options}}').
This feature will be removed in a future release. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.`
