### PR TITLE
Adds cmdline.txt configuration support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Use Ansible's `lineinfile` module to ensure certain settings are configured insi
 
 Use Ansible's `lineinfile` module to ensure certain settings are configured inside `/etc/rc.local`.
 
+    raspberry_pi_boot_cmdline_options: []
+
+Use Ansible's `replace` module to ensure certain settings are configured inside `/boot/cmdline.txt`.
+
 ## Dependencies
 
 None.
@@ -40,6 +44,10 @@ None.
     - hosts: pi
       vars_files:
         - vars/main.yml
+      vars:
+        raspberry_pi_boot_cmdline_options:
+          # Disable IPv6 during boot
+          - "ipv6.disable=1"
       roles:
         - { role: geerlingguy.raspberry-pi }
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,5 @@ raspberry_pi_rc_local_options:
   # Disable HDMI on startup (for power savings).
   - regexp: "^/usr/bin/tvservice"
     line: "/usr/bin/tvservice -o"
+
+raspberry_pi_boot_cmdline_options: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,3 +16,10 @@
     insertbefore: "^exit"
     state: present
   with_items: "{{ raspberry_pi_rc_local_options }}"
+
+- name: Configure options in /boot/cmdline.txt
+  replace:
+    path: /boot/cmdline.txt
+    regexp: '^([\w](?!.*\b{{ item }}\b).*)$'
+    replace: '\1 {{ item }}'
+  with_items: "{{ raspberry_pi_boot_cmdline_options }}"


### PR DESCRIPTION
Found this very useful post on Stackoverflow that uses Ansible's replace
module to configure settings in cmdline.txt and thought the clean
implementation and purpose fits this project.

Original post: https://stackoverflow.com/a/61974725
Original author: https://stackoverflow.com/users/2584475/jack