### PR TITLE
Added step to ensure /etc/rc.local exists.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,25 @@
     state: present
   with_items: "{{ raspberry_pi_boot_config_options }}"
 
-- name: Configure options in /etc/rc.local.
+- name: Ensure /etc/rc.local exists
+  copy:
+    dest: /etc/rc.local
+    content: |
+      #!/bin/sh -e
+      #
+      # rc.local
+      #
+      # This script is executed at the end of each multiuser runlevel.
+      # Make sure that the script will "exit 0" on success or any other
+      # value on error.
+      #
+      # By default this script does nothing.
+
+      exit 0
+    mode: '0755'
+    force: no
+
+- name: Configure options in /etc/rc.local
   lineinfile:
     dest: /etc/rc.local
     regexp: "{{ item.regexp }}"


### PR DESCRIPTION
## Description
Hi Jeff! 👋🏻 

I tried to run this on a freshly imaged Pi with Pi OS (64-bit) and it failed on an error related to `/etc/rc.local` not existing. I did a bit of digging and it seems like this is expected in newer versions of the system. Despite not being created by default, it does still work, so I have added a step to create `/etc/rc.local` if it does not exist.

