### PR TITLE
Patch /boot/firmware/config.txt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: Configure options in /boot/config.txt.
+- name: Configure options in /boot/firmware/config.txt.
   lineinfile:
-    dest: /boot/config.txt
+    dest: /boot/firmware/config.txt
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
     insertafter: EOF


### PR DESCRIPTION
## Problem / motivation

I recently installed a copy of Raspberry Pi OS Lite (64-bit) based on Debian Trixie. While auditing this playbook before running it to see if I could use it to help automate my setup, I ran `cat /etc/config.txt` to see what configuration options were in there, and found the contents of the file were...

```
DO NOT EDIT THIS FILE

The file you are looking for has moved to /boot/firmware/config.txt
```

I ran `cat /boot/firmware/config.txt` and found the configuration options that I was expecting.

I'm not exactly sure when this change was introduced, but I don't seem to remember this being a thing in Raspberry Pi OS Lite (64-bit) based on Debian Bookworm.

## Proposed resolution

Modify `/boot/firmware/config.txt` instead of `/boot/config.txt` in this playbook's `/tasks/main.yml`.

## Notes / disclaimers

I don't write a lot of Ansible professionally so I don't really know if I'm following best practices. For example, should I patch `/boot/config.txt` on Bookworm and lower; and `/boot/firmware/config.txt` on Trixie and higher?